### PR TITLE
Created .gitignore file and updated CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 test_results/
+.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-build/
-test_results/
+build
+test_results
 .ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+test_results/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 project(benchmark_gazebo)
 enable_testing()
 


### PR DESCRIPTION
Created a .gitignore file to ensure a smooth development process during further contributions and updated the root CMakeLists.txt file to have the minimum required CMake version as 3.10.2 (minimum version required in most of gazebo's repositories) since the previous minimum version seems to be deprecated and compatibility with versions < 2.8.12 will be removed from a future version of CMake. 