### PR TITLE
Dockerize the code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM gazebo
+SHELL ["/bin/bash", "-c"]
+
+RUN apt update && apt install -y cmake g++ libboost-all-dev  build-essential
+COPY . /app/
+RUN mkdir build 
+WORKDIR /app/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    cmake --build .
+
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /usr/share/gazebo/setup.bash
+make test


### PR DESCRIPTION
In issue #5 , it was discussed that a few manual commands need to be run, such as . /usr/share/gazebo/setup.bash. After merging this pull request, there will be no need for any additional actions. Additionally, there will be no operating system issues, as seen in the Ruby issue in Ubuntu 22 (#17 ).

Steps to build the image:-

`cd benchmark`
`sudo docker build -t <name_of_the_image> .` 

command to run the container:-
`sudo docker run <name_of_the_image>`