### PR TITLE
Set cone friction model in triball.world

### DIFF
--- a/worlds/triball.world
+++ b/worlds/triball.world
@@ -2,6 +2,14 @@
 
 <sdf version="1.5">
   <world name="default">
+    <physics type="ode">
+      <ode>
+        <solver>
+          <friction_model>cone_model</friction_model>
+        </solver>
+      </ode>
+    </physics>
+
     <include>
       <uri>model://ground_plane</uri>
     </include>

--- a/worlds/triball.world.erb
+++ b/worlds/triball.world.erb
@@ -11,6 +11,14 @@
 %>
 <sdf version="1.5">
   <world name="default">
+    <physics type="ode">
+      <ode>
+        <solver>
+          <friction_model>cone_model</friction_model>
+        </solver>
+      </ode>
+    </physics>
+
     <include>
       <uri>model://ground_plane</uri>
     </include>


### PR DESCRIPTION
This illustrates the different paths taken when started with the same linear velocity but different initial angular velocities.

With the default friction model: `pyramid_model`, the center model which does not spin travels a bit farther than the models with a small bit of initial angular velocity.


https://github.com/scpeters/benchmark/assets/3650755/d8c3d0eb-0af9-4390-9b88-95b45d7ff280



With the `cone_model`, the center model which has no initial angular velocity travels the shortest distance, which makes intuitive sense to me because it has the least amount of kinetic energy of any of the models. The models with the most angular velocity travel the farthest and exhibit some lateral motion as well.


https://github.com/scpeters/benchmark/assets/3650755/0fcf7ef1-2c26-4609-8491-9849dd2e3180

cc @yaswanth1701 